### PR TITLE
Update install_dependencies.sh

### DIFF
--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -34,7 +34,7 @@ url_treetagger=""
 if [ "$(uname)" == "Darwin" ]; then
   url_treetagger=http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-MacOSX-3.2-intel.tar.gz 
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  url_treetagger=http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-linux-3.2.tar.gz
+  url_treetagger=http://www.cis.uni-muenchen.de/~schmid/tools/TreeTagger/data/tree-tagger-linux-3.2-old.tar.gz
 else
   echo "`uname` platform not supported by this script. Install TreeTagger manually"
 fi


### PR DESCRIPTION
It downloaded another file, but did not extract it, leading to an empty treetagger bin file. This should fix the issue and download the correct file from the treetagger server. After which their install_tagger.sh script should extract the folder. 

This is the part in the treetagger install_taggel.sh script:

```
if [ -r tree-tagger-linux-3.2-old.tar.gz ]
then
    gzip -cd tree-tagger-linux-3.2-old.tar.gz | tar -xf -
    echo 'Linux version of TreeTagger (older kernels) installed.'
fi
```

Therefor it does not extract tree-tagger-linux-3.2.tar.gz
