### PR TITLE
adding name space for Alpino

### DIFF
--- a/treetagger_plain2naf.py
+++ b/treetagger_plain2naf.py
@@ -197,6 +197,7 @@ if __name__=='__main__':
     lp_term.set_version(__version__)
     lp_term.set_timestamp()
     knaf_obj.add_linguistic_processor('term', lp_term)
+    knaf_obj.root.set('{http://www.w3.org/XML/1998/namespace}lang', args.lang)
     
     knaf_obj.dump(sys.stdout)
  


### PR DESCRIPTION
This should omit the extra step of separately adding the language after using the treetagger. If the language is not added the Alpino wrapper you wrote can't parse the file and returns an error (lxml.etree.XMLSyntaxError). I think something like this can fix that.
